### PR TITLE
Fix specs to require a list of read library inputs for assemblers.

### DIFF
--- a/ui/narrative/methods/run_a5/spec.json
+++ b/ui/narrative/methods/run_a5/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_a6/spec.json
+++ b/ui/narrative/methods/run_a6/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_idba/spec.json
+++ b/ui/narrative/methods/run_idba/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_kiki/spec.json
+++ b/ui/narrative/methods/run_kiki/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_masurca/spec.json
+++ b/ui/narrative/methods/run_masurca/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_megahit/spec.json
+++ b/ui/narrative/methods/run_megahit/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_miniasm/spec.json
+++ b/ui/narrative/methods/run_miniasm/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_ray/spec.json
+++ b/ui/narrative/methods/run_ray/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_spades/spec.json
+++ b/ui/narrative/methods/run_spades/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {

--- a/ui/narrative/methods/run_velvet/spec.json
+++ b/ui/narrative/methods/run_velvet/spec.json
@@ -15,7 +15,7 @@
 	    "id": "read_library_names",
 	    "optional": false,
 	    "advanced": false,
-	    "allow_multiple": false,
+	    "allow_multiple": true,
 	    "default_values": [ "" ],
 	    "field_type": "text",
 	    "text_options": {


### PR DESCRIPTION
This should fix an ongoing issue with Assembly apps in Next. The input to the functions expects a list of read library names, but the specs are only set to create a string as a singleton.

Tagging @scanon
